### PR TITLE
翻訳書の原著年

### DIFF
--- a/biblatex/jpa.bbx
+++ b/biblatex/jpa.bbx
@@ -555,13 +555,19 @@
   }%
 }
 
+% origyear フィールドのフォーマットを定義
+\DeclareFieldFormat{origyear}{%
+  \mkbibparens{#1}%
+}
+
 %%% 翻訳書（origauthor使用の場合） %%%
 \newbibmacro*{translatedbook}{%
   \ifthenelse{\boolean{japanese}}{% 日本語文献
     \ifnameundef{origauthor}{}{%
       \renewcommand{\revsdnamepunct}{\addcomma\space}%
       \printnames[family-given]{origauthor}\setunit{\addperiod\addspace}%
-      \usebibmacro{date+extradate}\adddot\space%
+      % \usebibmacro{date+extradate}\adddot\space%
+      \printfield{origyear}\adddot\space % 原著出版年
       \printfield[emph]{origtitle}\setunit*{\adddot\space}%
       \printlist{origpublisher}\setunit*{\adddot\space}%
       \printtext{\\(}%


### PR DESCRIPTION
翻訳書があった時に，原著年が表示されず翻訳年が表示されるバグがありました。
翻訳書のorigyearを出すように修正しています。
この対応で良いかどうか含め，ご確認ください。